### PR TITLE
fix SQLDatabase deepcopy issue

### DIFF
--- a/langchain/sql_database.py
+++ b/langchain/sql_database.py
@@ -213,3 +213,7 @@ class SQLDatabase:
         except SQLAlchemyError as e:
             """Format the error message"""
             return f"Error: {e}"
+
+    def __deepcopy__(self, memo):
+        # Assuming DB does not need to be deep copied
+        return self


### PR DESCRIPTION
Bypassing deepcopy of SQLDatabase to avoid the Pydantic validation error for sql toolkit